### PR TITLE
added option to have the mode text either the right or left side

### DIFF
--- a/src/lib/Rating.svelte
+++ b/src/lib/Rating.svelte
@@ -8,6 +8,7 @@
 	export let maxRating = 5;
 	export let mode = EDIT_MODE;
 	export let color = '';
+	export let modeTextLeft = true
 
 	function updateSelectedRate(event) {
 		value = event.detail;
@@ -16,8 +17,9 @@
 </script>
 
 <div style={`pointer-events: ${mode === EDIT_MODE ? 'default' : 'none'}`}>
-	{mode}
+	{#if modeTextLeft}{mode}{/if}
 	{#each new Array(maxRating) as _star, index}
 		<Star {value} {color} index={index + 1} on:updateRate={updateSelectedRate} />
 	{/each}
+	{#if !modeTextLeft}{mode}{/if}
 </div>


### PR DESCRIPTION
If the text for the mode is on the left of the stars the stars won't align properly after the text, added and option to move the text to be on the right side instead of fixed at the left